### PR TITLE
docs: fix broken repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,5 +94,5 @@ Please note that the project explicitly does not require a CLA (Contributor Lice
 
 ## Contact
 
-Bug reports and patches are very welcome, please post them as GitHub issues and pull requests at https://github.com/aiven/{{PROJECT_NAME}} . 
+Bug reports and patches are very welcome, please post them as GitHub issues and pull requests at https://github.com/Aiven-Labs/python-apache-kafka-tutorial . 
 To report any possible vulnerabilities or other serious issues please see our [security](SECURITY.md) policy.


### PR DESCRIPTION
# About this change - What it does

Fixes a broken link in README.md
